### PR TITLE
Add root Makefile frontend targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,22 @@
 PYTHON ?= python3
 BATCH_SCRIPT := scripts/hot_sauce_batch.py
+FRONTEND_DIR := menu_display_2
 
-.PHONY: hot-sauce-csv hot-sauce-jsonl hot-sauce-batch hot-sauce-submit hot-sauce-resume hot-sauce-refresh
+.PHONY: up test lint build deploy hot-sauce-csv hot-sauce-jsonl hot-sauce-batch hot-sauce-check hot-sauce-submit hot-sauce-resume hot-sauce-refresh
+
+up:
+	cd $(FRONTEND_DIR) && npm run dev
+
+test: lint build
+
+lint:
+	cd $(FRONTEND_DIR) && npm run lint
+
+build:
+	cd $(FRONTEND_DIR) && npm run build
+
+deploy:
+	cd $(FRONTEND_DIR) && npm run deploy
 
 hot-sauce-csv:
 	$(PYTHON) $(BATCH_SCRIPT) --refresh-csv
@@ -11,6 +26,9 @@ hot-sauce-jsonl:
 
 hot-sauce-batch:
 	$(PYTHON) $(BATCH_SCRIPT)
+
+hot-sauce-check:
+	$(PYTHON) $(BATCH_SCRIPT) --poll-once
 
 hot-sauce-submit:
 	$(PYTHON) $(BATCH_SCRIPT) --submit-only


### PR DESCRIPTION
Add root-level make targets that proxy into the React app:\n\n-  starts Vite\n-  runs lint + build\n-  runs ESLint\n-  runs Vite production build\n-  runs the deploy script\n\nVerified with , , and .